### PR TITLE
Add dummy checkout for compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,6 +174,11 @@ module.exports = class Localdrive {
     const { keyname, filename } = keyResolve(this.root, key)
     return new FileWriteStream(filename, keyname, this, opts)
   }
+
+  checkout () {
+    // Dummy, for compatibility (no versioning with localdrive)
+    return this
+  }
 }
 
 function handleMetadataHooks (metadata) {

--- a/index.js
+++ b/index.js
@@ -25,6 +25,10 @@ module.exports = class Localdrive {
     return this
   }
 
+  checkout () {
+    return this
+  }
+
   toKey (filename) {
     if (filename.startsWith(this.root)) filename = filename.slice(this.root.length)
     return unixPathResolve('/', filename)
@@ -173,11 +177,6 @@ module.exports = class Localdrive {
   createWriteStream (key, opts) {
     const { keyname, filename } = keyResolve(this.root, key)
     return new FileWriteStream(filename, keyname, this, opts)
-  }
-
-  checkout () {
-    // Dummy, for compatibility (no versioning with localdrive)
-    return this
   }
 }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -52,3 +52,10 @@ test('batch()', function (t) {
   t.ok(batch.flush)
   t.ok(batch.close)
 })
+
+test('checkout()', function (t) {
+  const drive = createDrive(t)
+  const checkedOut = drive.checkout()
+
+  t.is(checkedOut, drive)
+})


### PR DESCRIPTION
Note: this returns the same object, which I think is different behaviour from hyperdrive (I don't think it's possible to add new entries to a checked-out hyperdrive)